### PR TITLE
No Sources Fix

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,5 +5,10 @@ let package = Package(
     dependencies: [
         .Package(url: "https://github.com/qutheory/vapor.git", majorVersion: 0),
         .Package(url: "https://github.com/qutheory/vapor-stencil.git", majorVersion: 0)
+    ],
+    exclude: [
+        "Deploy",
+        "Public",
+        "Resources"
     ]
 )


### PR DESCRIPTION
Added exclude parameter to Package.swift for 2/25 swifpm changes as it's currently throwing a "No Sources" error.
