### PR TITLE
[Docker] uses image from 'swiftdocker' repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,4 @@
-FROM ubuntu:14.04
-MAINTAINER matt@hilenium.com
-
-ENV SWIFT_BRANCH development
-ENV SWIFT_VERSION DEVELOPMENT-SNAPSHOT-2016-02-08-a
-ENV SWIFT_PLATFORM ubuntu14.04
-
-RUN apt-get update && \
-    apt-get install -y build-essential wget clang libedit-dev python2.7 python2.7-dev libicu52 rsync libxml2 git && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-RUN wget -q -O - https://swift.org/keys/all-keys.asc | gpg --import - && \
-    gpg --keyserver hkp://pool.sks-keyservers.net --refresh-keys Swift
-
-RUN SWIFT_ARCHIVE_NAME=swift-$SWIFT_VERSION-$SWIFT_PLATFORM && \
-    SWIFT_URL=https://swift.org/builds/$SWIFT_BRANCH/$(echo "$SWIFT_PLATFORM" | tr -d .)/swift-$SWIFT_VERSION/$SWIFT_ARCHIVE_NAME.tar.gz && \
-    wget $SWIFT_URL && \
-    wget $SWIFT_URL.sig && \
-    gpg --verify $SWIFT_ARCHIVE_NAME.tar.gz.sig && \
-    tar -xvzf $SWIFT_ARCHIVE_NAME.tar.gz --directory / --strip-components=1 && \
-    rm -rf $SWIFT_ARCHIVE_NAME* /tmp/* /var/tmp/*
+FROM swiftdocker/swift:latest
 
 ENV PATH /usr/bin:$PATH
 


### PR DESCRIPTION
The existing `Dockerfile` was similar to the one in the [`swiftdocker` repo](https://hub.docker.com/r/swiftdocker/swift/~/dockerfile/). I've successfully built (and deployed via _Docker Cloud_), with this commit.

This has the added benefit of keeping the version of Swift up-to-date when using Docker.

**Note:** [this error in SPM](https://github.com/kylef/PathKit/issues/11) prevents me from building the Vapor with Stencil. If removed, however, I'm able to build from this `Dockerfile`.
