### PR TITLE
[Docker] fix Stencil/SPM bug by running 'build'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV PATH /usr/bin:$PATH
 RUN mkdir -p /vapor
 WORKDIR /vapor
 ADD . /vapor
-RUN swift build
+RUN ./build
 
 EXPOSE 8080
 


### PR DESCRIPTION
Out-of-the-box, the `Dockerfile` fails to build the example as-is. This relies on the `build` script to get around failures.

To build: `$ docker build -t vapor .`
