### PR TITLE
Build script fixes

### DIFF
--- a/build
+++ b/build
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -e
 set -o pipefail

--- a/build
+++ b/build
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 echo "Downloading dependencies..."
-swift build
+swift build --fetch
 echo "Fixing SPM bug..."
 rm -rf Packages/*/Tests
 echo "Building..."

--- a/build
+++ b/build
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+set -e
+set -o pipefail
+
 echo "Downloading dependencies..."
 swift build --fetch
 echo "Fixing SPM bug..."

--- a/release
+++ b/release
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -e
 set -o pipefail

--- a/release
+++ b/release
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 echo "Downloading dependencies..."
-swift build
+swift build --fetch
 echo "Fixing SPM bug..."
 rm -rf Packages/*/Tests
 echo "Building..."

--- a/release
+++ b/release
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+set -e
+set -o pipefail
+
 echo "Downloading dependencies..."
 swift build --fetch
 echo "Fixing SPM bug..."

--- a/run
+++ b/run
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 set -e
 set -o pipefail

--- a/run
+++ b/run
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+set -e
+set -o pipefail
+
 ./build
 echo "Running..."
 .build/debug/App


### PR DESCRIPTION
- Fixed build scripts so they only fetch the dependencies the first time swift build is called, instead of trying and failing to build
- Updated build/run scripts to abort if an error occurs instead of blindly continuing
