### PR TITLE
Updated Dockerimage to use correct version of Swift

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM swiftdocker/swift:latest
+FROM swiftdocker/swift@sha256:c87f5a55a83ad2a8132b23b4faed6e1114f86bac0153a87e28f038b831339872
 
 ENV PATH /usr/bin:$PATH
 


### PR DESCRIPTION
Specified a digest in the Dockerfile in order to use
`DEVELOPMENT-SNAPSHOT-2016-05-03-a` instead of
`DEVELOPMENT-SNAPSHOT-2016-05-09-a`. Using the latest snapshot of Swift raises an error when building the project.
