### PR TITLE
Fixes UserController methods not being called,  throwing Abord.notFound | Vapor issue #444

### DIFF
--- a/App/Controllers/UserController.swift
+++ b/App/Controllers/UserController.swift
@@ -8,13 +8,13 @@ final class UserController: Resource {
         drop = droplet
     }
     
-    func index(_ request: Request) throws -> ResponseRepresentable {
+    func index(request: Request) throws -> ResponseRepresentable {
         return JSON([
             "controller": "UserController.index"
         ])
     }
 
-    func store(_ request: Request) throws -> ResponseRepresentable {
+    func store(request: Request) throws -> ResponseRepresentable {
         return JSON([
             "controller": "UserController.store"
         ])
@@ -24,7 +24,7 @@ final class UserController: Resource {
     	Since item is of type User,
     	only instances of user will be received
     */
-    func show(_ request: Request, item user: User) throws -> ResponseRepresentable {
+    func show(request: Request, item user: User) throws -> ResponseRepresentable {
         //User can be used like JSON with JsonRepresentable
         return JSON([
             "controller": "UserController.show",
@@ -32,12 +32,12 @@ final class UserController: Resource {
         ])
     }
 
-    func update(_ request: Request, item user: User) throws -> ResponseRepresentable {
+    func update(request: Request, item user: User) throws -> ResponseRepresentable {
         //User is JsonRepresentable
         return user.makeJSON()
     }
 
-    func destroy(_ request: Request, item user: User) throws -> ResponseRepresentable {
+    func destroy(request: Request, item user: User) throws -> ResponseRepresentable {
         //User is ResponseRepresentable by proxy of JsonRepresentable
         return user
     }


### PR DESCRIPTION
Fixes the resources routing system in the example.
Indeed, the example uses a method definition as : 
`method(_ request:Request)` 
while the resource routing in Vapor uses 
`method(request:Request)` 
which made Vapor automatically call the wrong definition present in the Resource protocol extension which led to an Abord.notFound error.
